### PR TITLE
Make NuGet package include template targets by default

### DIFF
--- a/BeatSaberModdingTools.Tasks/BSMT.DefaultProps.props
+++ b/BeatSaberModdingTools.Tasks/BSMT.DefaultProps.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DisableCopyToPlugins>true</DisableCopyToPlugins>
+    <DisableZipRelease>true</DisableZipRelease>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(NCrunch)' == '1'">
+    <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
+    <DisableCopyToPlugins>true</DisableCopyToPlugins>
+    <DisableZipRelease>true</DisableZipRelease>
+  </PropertyGroup>
+</Project>

--- a/BeatSaberModdingTools.Tasks/BSMT.DefaultTargets.targets
+++ b/BeatSaberModdingTools.Tasks/BSMT.DefaultTargets.targets
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  
+  <PropertyGroup>
+    <BuildTargetsVersion>2.0</BuildTargetsVersion>
+    <!--Set this to true if you edit this file to prevent automatic updates-->
+    <BuildTargetsModified>false</BuildTargetsModified>
+    <!--Output assembly path without extension-->
+    <OutputAssemblyName>$(OutputPath)$(AssemblyName)</OutputAssemblyName>
+    <!--Path to folder to be zipped. Needs to be relative to the project directory to work without changes to the 'BuildForCI' target.-->
+    <ArtifactDestination>$(OutputPath)Final</ArtifactDestination>
+    <ErrorOnMismatchedVersions Condition="'$(Configuration)' == 'Release'">True</ErrorOnMismatchedVersions>
+  </PropertyGroup>
+  
+  <!--Build Targets-->
+  <!--Displays a warning if BeatSaberModdingTools.Tasks is not installed.-->
+  <Target Name="CheckBSMTInstalled" AfterTargets="BeforeBuild" Condition="'$(BSMTTaskAssembly)' == ''">
+    <Warning Text="The BeatSaberModdingTools.Tasks nuget package doesn't seem to be installed, advanced build targets will not work." />
+  </Target>
+  
+  <!--Runs a build task to get info about the project used by later targets.-->
+  <Target Name="GetProjectInfo" AfterTargets="CheckBSMTInstalled" DependsOnTargets="CheckBSMTInstalled" Condition="'$(BSMTTaskAssembly)' != ''">
+    <Message Text="Using AssemblyVersion defined in project instead of 'Properties\AssemblyInfo.cs'" Importance="high" Condition="'$(AssemblyVersion)' != ''" />
+    
+    <GetManifestInfo KnownAssemblyVersion="$(AssemblyVersion)" ErrorOnMismatch="$(ErrorOnMismatchedVersions)">
+      <Output TaskParameter="PluginVersion" PropertyName="PluginVersion" />
+      <Output TaskParameter="GameVersion" PropertyName="GameVersion" />
+      <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
+    </GetManifestInfo>
+    
+    <GetCommitInfo ProjectDir="$(ProjectDir)">
+      <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
+      <Output TaskParameter="Branch" PropertyName="Branch" />
+      <Output TaskParameter="Modified" PropertyName="GitModified" />
+    </GetCommitInfo>
+    
+    <PropertyGroup>
+      <!--Build name for artifact/zip file-->
+      <ArtifactName>$(AssemblyName)</ArtifactName>
+      <ArtifactName Condition="'$(PluginVersion)' != ''">$(ArtifactName)-$(PluginVersion)</ArtifactName>
+      <ArtifactName Condition="'$(GameVersion)' != ''">$(ArtifactName)-bs$(GameVersion)</ArtifactName>
+      <ArtifactName Condition="'$(CommitHash)' != '' AND '$(CommitHash)' != 'local'">$(ArtifactName)-$(CommitHash)</ArtifactName>
+    </PropertyGroup>
+  </Target>
+  
+  <!--Build target for Continuous Integration builds. Set up for GitHub Actions.-->
+  <Target Name="BuildForCI" AfterTargets="Build" DependsOnTargets="GetProjectInfo" Condition="'$(ContinuousIntegrationBuild)' == 'True' AND '$(BSMTTaskAssembly)' != ''">
+    <PropertyGroup>
+      <!--Set 'ArtifactName' if it failed before.-->
+      <ArtifactName Condition="'$(ArtifactName)' == ''">$(AssemblyName)</ArtifactName>
+    </PropertyGroup>
+    <Message Text="Building for CI" Importance="high" />
+    <Message Text="PluginVersion: $(PluginVersion), AssemblyVersion: $(AssemblyVersion), GameVersion: $(GameVersion)" Importance="high" />
+    <Message Text="::set-output name=filename::$(ArtifactName)" Importance="high" />
+    <Message Text="::set-output name=assemblyname::$(AssemblyName)" Importance="high" />
+    <Message Text="::set-output name=artifactpath::$(ProjectDir)$(ArtifactDestination)" Importance="high" />
+    <Message Text="Copying '$(OutputAssemblyName).dll' to '$(ProjectDir)$(ArtifactDestination)\Plugins\$(AssemblyName).dll'" Importance="high" />
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(ProjectDir)$(ArtifactDestination)\Plugins\$(AssemblyName).dll" />
+  </Target>
+  
+  <!--Creates a BeatMods compliant zip file with the release.-->
+  <Target Name="ZipRelease" AfterTargets="Build" Condition="'$(DisableZipRelease)' != 'True' AND '$(Configuration)' == 'Release' AND '$(BSMTTaskAssembly)' != ''">
+    <PropertyGroup>
+      <!--Set 'ArtifactName' if it failed before.-->
+      <ArtifactName Condition="'$(ArtifactName)' == ''">$(AssemblyName)</ArtifactName>
+      <DestinationDirectory>$(OutDir)zip\</DestinationDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <OldZips Include="$(DestinationDirectory)$(AssemblyName)*.zip"/>
+    </ItemGroup>
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(ArtifactDestination)\Plugins\$(AssemblyName).dll" />
+    <Message Text="PluginVersion: $(PluginVersion), AssemblyVersion: $(AssemblyVersion), GameVersion: $(GameVersion)" Importance="high" />
+    <Delete Files="@(OldZips)" TreatErrorsAsWarnings="true" ContinueOnError="true" />
+    <ZipDir SourceDirectory="$(ArtifactDestination)" DestinationFile="$(DestinationDirectory)$(ArtifactName).zip" />
+  </Target>
+  
+  <!--Copies the assembly and pdb to the Beat Saber folder.-->
+  <Target Name="CopyToPlugins" AfterTargets="Build" Condition="'$(DisableCopyToPlugins)' != 'True' AND '$(ContinuousIntegrationBuild)' != 'True'">
+    <PropertyGroup>
+      <PluginDir>$(BeatSaberDir)\Plugins</PluginDir>
+      <CanCopyToPlugins>True</CanCopyToPlugins>
+      <CopyToPluginsError Condition="!Exists('$(PluginDir)')">Unable to copy assembly to game folder, did you set 'BeatSaberDir' correctly in your 'csproj.user' file? Plugins folder doesn't exist: '$(PluginDir)'.</CopyToPluginsError>
+      <!--Error if 'BeatSaberDir' does not have 'Beat Saber.exe'-->
+      <CopyToPluginsError Condition="!Exists('$(BeatSaberDir)\Beat Saber.exe')">Unable to copy to Plugins folder, '$(BeatSaberDir)' does not appear to be a Beat Saber game install.</CopyToPluginsError>
+      <!--Error if 'BeatSaberDir' is the same as 'LocalRefsDir'-->
+      <CopyToPluginsError Condition="'$(BeatSaberDir)' == '$(LocalRefsDir)' OR '$(BeatSaberDir)' == ''">Unable to copy to Plugins folder, 'BeatSaberDir' has not been set in your 'csproj.user' file.</CopyToPluginsError>
+      <CanCopyToPlugins Condition="'$(CopyToPluginsError)' != ''">False</CanCopyToPlugins>
+    </PropertyGroup>
+    
+    <!--Check if Beat Saber is running-->
+    <IsProcessRunning ProcessName="Beat Saber" Condition="'$(BSMTTaskAssembly)' != ''">
+      <Output TaskParameter="IsRunning" PropertyName="IsRunning" />
+    </IsProcessRunning>
+    
+    <PropertyGroup>
+      <!--If Beat Saber is running, output to the Pending folder-->
+      <PluginDir Condition="'$(IsRunning)' == 'True'">$(BeatSaberDir)\IPA\Pending\Plugins</PluginDir>
+    </PropertyGroup>
+    
+    <Warning Text="$(CopyToPluginsError)" Condition="'$(CopyToPluginsError)' != ''" />
+    <Message Text="Copying '$(OutputAssemblyName).dll' to '$(PluginDir)'." Importance="high" Condition="$(CanCopyToPlugins)" />
+    
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(PluginDir)\$(AssemblyName).dll" Condition="$(CanCopyToPlugins)"  />
+    <Copy SourceFiles="$(OutputAssemblyName).pdb" DestinationFiles="$(PluginDir)\$(AssemblyName).pdb" Condition="'$(CanCopyToPlugins)' == 'True' AND Exists('$(OutputAssemblyName).pdb')"  />
+    
+    <Warning Text="Beat Saber is running, restart the game to use the latest build." Condition="'$(IsRunning)' == 'True'" />
+  </Target>
+  
+</Project>

--- a/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.TargetFramework.props
+++ b/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.TargetFramework.props
@@ -14,7 +14,9 @@
     <BSMTTaskFolder Condition="!$(IsNetCoreApp)">net46</BSMTTaskFolder> -->
     <BSMTTaskFolder>netstandard2.0</BSMTTaskFolder>
     <BSMTTaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(BSMTTaskFolder)\BeatSaberModdingTools.Tasks.dll</BSMTTaskAssembly>
+    <ImportBSMTTargets>true</ImportBSMTTargets>
   </PropertyGroup>
+  
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.CompareVersions" AssemblyFile="$(BSMTTaskAssembly)" />
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.GetAssemblyInfo" AssemblyFile="$(BSMTTaskAssembly)" />
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.GetCommitInfo" AssemblyFile="$(BSMTTaskAssembly)" />
@@ -23,4 +25,6 @@
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.ReplaceInFile" AssemblyFile="$(BSMTTaskAssembly)" />
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.ZipDir" AssemblyFile="$(BSMTTaskAssembly)" />
   <UsingTask TaskName="BeatSaberModdingTools.Tasks.GenerateManifest" AssemblyFile="$(BSMTTaskAssembly)" />
+
+  <Import Project="$(MSBuildThisFileDirectory)BSMT.DefaultProps.props"/>
 </Project>

--- a/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.csproj
+++ b/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.csproj
@@ -13,9 +13,11 @@
     <RepositoryUrl>https://github.com/Zingabopp/BeatSaberModdingTools.Tasks.git</RepositoryUrl>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+  
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>BeatSaberModdingTools.Tasks</RootNamespace>
@@ -37,6 +39,7 @@
     <developmentDependency>true</developmentDependency>
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
+  
   <PropertyGroup>
     <DocumentationFile>BeatSaberModdingTools.Tasks.xml</DocumentationFile>
     <PackageTags>Beat Saber;BeatSaberModdingTools</PackageTags>
@@ -49,6 +52,9 @@
 
   <ItemGroup>
     <Content Include="BeatSaberModdingTools.Tasks.TargetFramework.props" Pack="true" PackagePath="build\BeatSaberModdingTools.Tasks.props" />
+    <Content Include="BeatSaberModdingTools.Tasks.targets" Pack="true" PackagePath="build\BeatSaberModdingTools.Tasks.targets" />
+    <Content Include="BSMT.DefaultProps.props" Pack="true" PackagePath="build\BSMT.DefaultProps.props" />
+    <Content Include="BSMT.DefaultTargets.targets" Pack="true" PackagePath="build\BSMT.DefaultTargets.targets" />
     <!--<Content Include="BeatSaberModdingTools.Tasks.TargetFrameworks.props" Pack="true" PackagePath="buildMultiTargeting\BeatSaberModdingTools.Tasks.props" />-->
   </ItemGroup>
 
@@ -65,19 +71,31 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- NuGetizer makes controlling NuGet pack *much* nicer -->
+    <PackageReference Include="NuGetizer" Version="0.7.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'True'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.5.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
+  
   <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>-->
+  
   <Target Name="GithubActionsInfo" AfterTargets="Build">
     <Message Text="::set-output name=filename::$(AssemblyName)-$(PackageVersion)" Importance="high" />
     <Message Text="::set-output name=assemblyname::$(AssemblyName)" Importance="high" />

--- a/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.targets
+++ b/BeatSaberModdingTools.Tasks/BeatSaberModdingTools.Tasks.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)BSMT.DefaultTargets.targets" Condition="'$(ImportBSMTTargets)' != 'false'"/>
+  
+</Project>


### PR DESCRIPTION
This should help to alleviate the difficulties with package updates in the templates.

 Consumers of the package can also set `<ImportBSMTTargets>false</ImportBSMTTargets>` to prevent the default targets from being included. 